### PR TITLE
build: Fix debug build

### DIFF
--- a/Programming_Qt.vcxproj
+++ b/Programming_Qt.vcxproj
@@ -63,6 +63,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">


### PR DESCRIPTION
Debug build previously linked to non-debug C++ runtime while the qt library linked to the conflicting debug C++ runtime. This conflict resulted in a build warning and an exception at runtime when the Window() constructor called into Qt6Cored.dll.

Debug build generated by the corrected .vcxproj tested working, and DLL dependency tree inspected to ensure runtime conflict is resolved.