### PR TITLE
Update Graph.h to reflect text on page 482 of PPP3

### DIFF
--- a/PPP/Graph.h
+++ b/PPP/Graph.h
@@ -261,6 +261,12 @@ struct Polygon : Closed_polyline {	// closed sequence of non-intersecting lines
 
 struct Lines : Shape {	// independent lines
     Lines(initializer_list<Point> lst = {}) : Shape{lst} { if (lst.size() % 2) error("odd number of points for Lines"); }
+    Lines(initializer_list<pair<Point,Point>> lst) {
+        for (const auto& line_pair : lst) {
+	    Shape::add(line_pair.first);
+	    Shape::add(line_pair.second);
+	    }
+	}
     void draw_specifics(Painter& painter) const override;
     void add(Point p1, Point p2) { Shape::add(p1); Shape::add(p2); redraw();}
 };


### PR DESCRIPTION
As is, the code is incompatible with Lines' initialization formats shown in the examples on page 482 of the PPP3 textbook. Adding the proposed lines remedies the incompatibility.  

Also, this is my first ever proposed change / pull request on GitHub so I apologize ahead of time if I am making this proposal incorrectly!